### PR TITLE
ci: add manual workflow_dispatch trigger for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,17 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      version_increment:
+        description: Version increment type
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -22,6 +33,12 @@ jobs:
       - name: Check changed files
         id: check
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual trigger — proceeding with release"
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
           echo "Changed files:"
           echo "$CHANGED_FILES"
@@ -72,9 +89,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine version bump from commits
+      - name: Determine version bump
         id: bump
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "bump=${{ github.event.inputs.version_increment }}" >> $GITHUB_OUTPUT
+            echo "Manual trigger — using: ${{ github.event.inputs.version_increment }}"
+            exit 0
+          fi
+
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -z "$LAST_TAG" ]; then
             COMMITS=$(git log --pretty=format:"%s" HEAD)


### PR DESCRIPTION
## 📝 Description

Adds a `workflow_dispatch` trigger to the release workflow, allowing a release to be triggered manually from the GitHub Actions UI on the `main` branch.

## 🎯 Related Issue

N/A

## 🔄 Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## ✅ Checklist

- [x] My code follows the project's code style
- [x] All new and existing tests pass (`go test ./... -race`)
- [x] I have updated documentation if needed

## 📎 Additional Notes

When triggered manually via **Actions → Release → Run workflow**, a dropdown lets you choose the version bump:

- `patch` (default) — e.g. `v1.0.0` → `v1.0.1`
- `minor` — e.g. `v1.0.0` → `v1.1.0`
- `major` — e.g. `v1.0.0` → `v2.0.0`

On a manual trigger:
- The file-change check is skipped (always proceeds to release)
- The chosen bump is used directly instead of analyzing commit messages
- CI still runs before the tag is created
