### PR TITLE
fix: use GH_PAT for tag push so release-publish workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,4 +140,4 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag ${{ steps.version.outputs.tag }}
-          git push origin ${{ steps.version.outputs.tag }}
+          git push https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }} ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
## 📝 Description

Fixes the release pipeline: the `release-publish` workflow was never triggered after a tag was pushed.

## Root Cause

GitHub intentionally does not trigger workflows on events caused by `GITHUB_TOKEN`. Since the tag was pushed using `GITHUB_TOKEN`, the `on: push: tags` trigger in `release-publish.yml` was silently ignored.

## Fix

Use `GH_PAT` (a Personal Access Token) for the tag push instead. Events caused by a PAT are treated as user-initiated and do trigger downstream workflows.

> **Note:** `GH_PAT` must be set as a repository secret with `Contents: write` permission.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## ✅ Checklist

- [x] My code follows the project's code style
- [x] All new and existing tests pass (`go test ./... -race`)
- [x] I have updated documentation if needed
