### PR TITLE
feat: replace panics with errors in composite spec constructors

### DIFF
--- a/examples/loan/main.go
+++ b/examples/loan/main.go
@@ -49,11 +49,13 @@ func main() {
 	// --- Build composite specification ---
 	// Applicant is financially qualified if they have good credit OR (sufficient income AND is employed)
 	incomeAndEmployment, err := spec.AllOf("IncomeAndEmployment", incomeCheck, employmentCheck)
+
 	if err != nil {
 		panic(err)
 	}
 
 	financiallyQualified, err := spec.AnyOf("FinanciallyQualified", creditCheck, incomeAndEmployment)
+
 	if err != nil {
 		panic(err)
 	}

--- a/examples/loan/main.go
+++ b/examples/loan/main.go
@@ -48,10 +48,15 @@ func main() {
 
 	// --- Build composite specification ---
 	// Applicant is financially qualified if they have good credit OR (sufficient income AND is employed)
-	financiallyQualified := spec.AnyOf("FinanciallyQualified",
-		creditCheck,
-		spec.AllOf("IncomeAndEmployment", incomeCheck, employmentCheck),
-	)
+	incomeAndEmployment, err := spec.AllOf("IncomeAndEmployment", incomeCheck, employmentCheck)
+	if err != nil {
+		panic(err)
+	}
+
+	financiallyQualified, err := spec.AnyOf("FinanciallyQualified", creditCheck, incomeAndEmployment)
+	if err != nil {
+		panic(err)
+	}
 
 	// --- Build policy ---
 	loanPolicy := spec.NewPolicy[LoanApplicationContext, LoanIneligibilityReason]().

--- a/pkg/spec/composite.go
+++ b/pkg/spec/composite.go
@@ -1,106 +1,128 @@
 package spec
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
 
 // AnyOf returns a [Specification] that passes if any of the given specifications pass (OR logic).
 // Evaluation short-circuits on the first passing specification.
-// Panics if no specifications are provided.
-func AnyOf[T any, R comparable](name string, specs ...Specification[T, R]) Specification[T, R] {
+// Returns an error if no specifications are provided.
+func AnyOf[T any, R comparable](name string, specs ...Specification[T, R]) (Specification[T, R], error) {
 	if len(specs) == 0 {
-		panic("AnyOf requires at least one specification")
+		return nil, errors.New("AnyOf requires at least one specification")
 	}
+
 	expr := buildExpression(specs, " OR ")
+
 	return Func[T, R]{
 		name:       name,
 		expression: expr,
 		fn: func(ctx T) SpecificationResult[R] {
 			var reasons []R
+
 			for _, s := range specs {
 				res := s.Evaluate(ctx)
+
 				if res.Passed() {
 					return Pass[R](name)
 				}
+
 				reasons = append(reasons, res.FailureReasons()...)
 			}
+
 			return Fail(name, reasons...)
 		},
-	}
+	}, nil
 }
 
 // AnyOfAll returns a [Specification] that passes if any of the given specifications pass (OR logic).
 // Unlike [AnyOf], all specifications are always evaluated — no short-circuiting.
-// Panics if no specifications are provided.
-func AnyOfAll[T any, R comparable](name string, specs ...Specification[T, R]) Specification[T, R] {
+// Returns an error if no specifications are provided.
+func AnyOfAll[T any, R comparable](name string, specs ...Specification[T, R]) (Specification[T, R], error) {
 	if len(specs) == 0 {
-		panic("AnyOfAll requires at least one specification")
+		return nil, errors.New("AnyOfAll requires at least one specification")
 	}
+
 	expr := buildExpression(specs, " OR ")
+
 	return Func[T, R]{
 		name:       name,
 		expression: expr,
 		fn: func(ctx T) SpecificationResult[R] {
 			anyPassed := false
 			var reasons []R
+
 			for _, s := range specs {
 				res := s.Evaluate(ctx)
+
 				if res.Passed() {
 					anyPassed = true
 				} else {
 					reasons = append(reasons, res.FailureReasons()...)
 				}
 			}
+
 			if anyPassed {
 				return Pass[R](name)
 			}
+
 			return Fail(name, reasons...)
 		},
-	}
+	}, nil
 }
 
 // AllOf returns a [Specification] that passes only if all of the given specifications pass (AND logic).
 // All specifications are always evaluated regardless of intermediate results.
-// Panics if no specifications are provided.
-func AllOf[T any, R comparable](name string, specs ...Specification[T, R]) Specification[T, R] {
+// Returns an error if no specifications are provided.
+func AllOf[T any, R comparable](name string, specs ...Specification[T, R]) (Specification[T, R], error) {
 	if len(specs) == 0 {
-		panic("AllOf requires at least one specification")
+		return nil, errors.New("AllOf requires at least one specification")
 	}
+
 	expr := buildExpression(specs, " AND ")
+
 	return Func[T, R]{
 		name:       name,
 		expression: expr,
 		fn: func(ctx T) SpecificationResult[R] {
 			allPassed := true
 			var reasons []R
+
 			for _, s := range specs {
 				res := s.Evaluate(ctx)
+
 				if !res.Passed() {
 					allPassed = false
 					reasons = append(reasons, res.FailureReasons()...)
 				}
 			}
+
 			if allPassed {
 				return Pass[R](name)
 			}
+
 			return Fail(name, reasons...)
 		},
-	}
+	}, nil
 }
 
 // Not returns a [Specification] that passes when the given specification fails, and fails otherwise.
 // The provided failureReason is used when the inner specification passes (i.e., the Not fails).
 func Not[T any, R comparable](name string, failureReason R, s Specification[T, R]) Specification[T, R] {
 	expr := fmt.Sprintf("NOT %s", s.Expression())
+
 	return Func[T, R]{
 		name:       name,
 		expression: expr,
 		fn: func(ctx T) SpecificationResult[R] {
 			res := s.Evaluate(ctx)
+
 			if !res.Passed() {
 				return Pass[R](name)
 			}
+
 			return Fail(name, failureReason)
 		},
 	}
@@ -110,9 +132,12 @@ func buildExpression[T any, R comparable](specs []Specification[T, R], sep strin
 	if len(specs) == 1 {
 		return specs[0].Expression()
 	}
+
 	parts := make([]string, len(specs))
+
 	for i, s := range specs {
 		parts[i] = s.Expression()
 	}
+
 	return fmt.Sprintf("(%s)", strings.Join(parts, sep))
 }

--- a/pkg/spec/composite_test.go
+++ b/pkg/spec/composite_test.go
@@ -9,7 +9,10 @@ import (
 // --- AnyOf ---
 
 func TestAnyOf_PassesWhenFirstSpecPasses(t *testing.T) {
-	s := spec.AnyOf("combo", isAdult, hasFunds)
+	s, err := spec.AnyOf("combo", isAdult, hasFunds)
+	if err != nil {
+		t.Fatal(err)
+	}
 	result := s.Evaluate(testCtx{Age: 20, Balance: 0})
 	if !result.Passed() {
 		t.Error("expected pass when first spec passes")
@@ -17,7 +20,10 @@ func TestAnyOf_PassesWhenFirstSpecPasses(t *testing.T) {
 }
 
 func TestAnyOf_PassesWhenSecondSpecPasses(t *testing.T) {
-	s := spec.AnyOf("combo", isAdult, hasFunds)
+	s, err := spec.AnyOf("combo", isAdult, hasFunds)
+	if err != nil {
+		t.Fatal(err)
+	}
 	result := s.Evaluate(testCtx{Age: 16, Balance: 200})
 	if !result.Passed() {
 		t.Error("expected pass when second spec passes")
@@ -25,7 +31,10 @@ func TestAnyOf_PassesWhenSecondSpecPasses(t *testing.T) {
 }
 
 func TestAnyOf_FailsWhenAllSpecsFail(t *testing.T) {
-	s := spec.AnyOf("combo", isAdult, hasFunds)
+	s, err := spec.AnyOf("combo", isAdult, hasFunds)
+	if err != nil {
+		t.Fatal(err)
+	}
 	result := s.Evaluate(testCtx{Age: 16, Balance: 50})
 	if result.Passed() {
 		t.Error("expected fail when all specs fail")
@@ -33,7 +42,10 @@ func TestAnyOf_FailsWhenAllSpecsFail(t *testing.T) {
 }
 
 func TestAnyOf_CollectsAllReasonsOnFailure(t *testing.T) {
-	s := spec.AnyOf("combo", isAdult, hasFunds)
+	s, err := spec.AnyOf("combo", isAdult, hasFunds)
+	if err != nil {
+		t.Fatal(err)
+	}
 	result := s.Evaluate(testCtx{Age: 16, Balance: 50})
 	if len(result.FailureReasons()) != 2 {
 		t.Errorf("FailureReasons() len = %d, want 2", len(result.FailureReasons()))
@@ -51,7 +63,10 @@ func TestAnyOf_ShortCircuitsOnFirstPass(t *testing.T) {
 		return true
 	}, blocked)
 
-	s := spec.AnyOf("combo", counter, never)
+	s, err := spec.AnyOf("combo", counter, never)
+	if err != nil {
+		t.Fatal(err)
+	}
 	s.Evaluate(testCtx{})
 
 	if evalCount != 1 {
@@ -60,7 +75,10 @@ func TestAnyOf_ShortCircuitsOnFirstPass(t *testing.T) {
 }
 
 func TestAnyOf_Expression(t *testing.T) {
-	s := spec.AnyOf("combo", isAdult, hasFunds)
+	s, err := spec.AnyOf("combo", isAdult, hasFunds)
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := "(IsAdult OR HasFunds)"
 	if s.Expression() != want {
 		t.Errorf("Expression() = %q, want %q", s.Expression(), want)
@@ -68,19 +86,20 @@ func TestAnyOf_Expression(t *testing.T) {
 }
 
 func TestAnyOf_SingleSpec(t *testing.T) {
-	s := spec.AnyOf("single", isAdult)
+	s, err := spec.AnyOf("single", isAdult)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if s.Expression() != "IsAdult" {
 		t.Errorf("Expression() = %q, want %q", s.Expression(), "IsAdult")
 	}
 }
 
-func TestAnyOf_PanicsOnEmpty(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for empty specs")
-		}
-	}()
-	spec.AnyOf[testCtx, testReason]("empty")
+func TestAnyOf_ErrorOnEmpty(t *testing.T) {
+	_, err := spec.AnyOf[testCtx, testReason]("empty")
+	if err == nil {
+		t.Error("expected error for empty specs")
+	}
 }
 
 // --- AnyOfAll ---
@@ -90,7 +109,10 @@ func TestAnyOfAll_EvaluatesAllSpecs(t *testing.T) {
 	s1 := spec.New("S1", func(c testCtx) bool { evalCount++; return true }, blocked)
 	s2 := spec.New("S2", func(c testCtx) bool { evalCount++; return false }, blocked)
 
-	s := spec.AnyOfAll("combo", s1, s2)
+	s, err := spec.AnyOfAll("combo", s1, s2)
+	if err != nil {
+		t.Fatal(err)
+	}
 	result := s.Evaluate(testCtx{})
 
 	if evalCount != 2 {
@@ -102,23 +124,27 @@ func TestAnyOfAll_EvaluatesAllSpecs(t *testing.T) {
 }
 
 func TestAnyOfAll_FailsWhenAllFail(t *testing.T) {
-	s := spec.AnyOfAll("combo", alwaysFail, alwaysFail)
+	s, err := spec.AnyOfAll("combo", alwaysFail, alwaysFail)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if s.Evaluate(testCtx{}).Passed() {
 		t.Error("expected fail when all specs fail")
 	}
 }
 
-func TestAnyOfAll_PanicsOnEmpty(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for empty specs")
-		}
-	}()
-	spec.AnyOfAll[testCtx, testReason]("empty")
+func TestAnyOfAll_ErrorOnEmpty(t *testing.T) {
+	_, err := spec.AnyOfAll[testCtx, testReason]("empty")
+	if err == nil {
+		t.Error("expected error for empty specs")
+	}
 }
 
 func TestAnyOfAll_CollectsAllReasonsOnFailure(t *testing.T) {
-	s := spec.AnyOfAll("combo", isAdult, hasFunds)
+	s, err := spec.AnyOfAll("combo", isAdult, hasFunds)
+	if err != nil {
+		t.Fatal(err)
+	}
 	result := s.Evaluate(testCtx{Age: 16, Balance: 50})
 	if result.Passed() {
 		t.Error("expected fail")
@@ -131,7 +157,10 @@ func TestAnyOfAll_CollectsAllReasonsOnFailure(t *testing.T) {
 // --- AllOf ---
 
 func TestAllOf_PassesWhenAllSpecsPass(t *testing.T) {
-	s := spec.AllOf("combo", isAdult, hasFunds)
+	s, err := spec.AllOf("combo", isAdult, hasFunds)
+	if err != nil {
+		t.Fatal(err)
+	}
 	result := s.Evaluate(testCtx{Age: 20, Balance: 200})
 	if !result.Passed() {
 		t.Error("expected pass when all specs pass")
@@ -139,7 +168,10 @@ func TestAllOf_PassesWhenAllSpecsPass(t *testing.T) {
 }
 
 func TestAllOf_FailsWhenFirstFails(t *testing.T) {
-	s := spec.AllOf("combo", isAdult, hasFunds)
+	s, err := spec.AllOf("combo", isAdult, hasFunds)
+	if err != nil {
+		t.Fatal(err)
+	}
 	result := s.Evaluate(testCtx{Age: 16, Balance: 200})
 	if result.Passed() {
 		t.Error("expected fail when first spec fails")
@@ -147,7 +179,10 @@ func TestAllOf_FailsWhenFirstFails(t *testing.T) {
 }
 
 func TestAllOf_CollectsAllFailureReasons(t *testing.T) {
-	s := spec.AllOf("combo", isAdult, hasFunds)
+	s, err := spec.AllOf("combo", isAdult, hasFunds)
+	if err != nil {
+		t.Fatal(err)
+	}
 	result := s.Evaluate(testCtx{Age: 16, Balance: 50})
 	if len(result.FailureReasons()) != 2 {
 		t.Errorf("FailureReasons() len = %d, want 2", len(result.FailureReasons()))
@@ -159,7 +194,11 @@ func TestAllOf_EvaluatesAllSpecsEvenOnFailure(t *testing.T) {
 	s1 := spec.New("S1", func(c testCtx) bool { evalCount++; return false }, tooYoung)
 	s2 := spec.New("S2", func(c testCtx) bool { evalCount++; return false }, insufficientFunds)
 
-	spec.AllOf("combo", s1, s2).Evaluate(testCtx{})
+	s, err := spec.AllOf("combo", s1, s2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Evaluate(testCtx{})
 
 	if evalCount != 2 {
 		t.Errorf("evalCount = %d, want 2", evalCount)
@@ -167,20 +206,21 @@ func TestAllOf_EvaluatesAllSpecsEvenOnFailure(t *testing.T) {
 }
 
 func TestAllOf_Expression(t *testing.T) {
-	s := spec.AllOf("combo", isAdult, hasFunds)
+	s, err := spec.AllOf("combo", isAdult, hasFunds)
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := "(IsAdult AND HasFunds)"
 	if s.Expression() != want {
 		t.Errorf("Expression() = %q, want %q", s.Expression(), want)
 	}
 }
 
-func TestAllOf_PanicsOnEmpty(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for empty specs")
-		}
-	}()
-	spec.AllOf[testCtx, testReason]("empty")
+func TestAllOf_ErrorOnEmpty(t *testing.T) {
+	_, err := spec.AllOf[testCtx, testReason]("empty")
+	if err == nil {
+		t.Error("expected error for empty specs")
+	}
 }
 
 // --- Not ---
@@ -216,10 +256,14 @@ func TestNot_Expression(t *testing.T) {
 // --- Nesting ---
 
 func TestNested_AnyOfWithAllOf(t *testing.T) {
-	financiallyQualified := spec.AnyOf("FinanciallyQualified",
-		hasFunds,
-		spec.AllOf("VerifiedAndAdult", isVerified, isAdult),
-	)
+	verifiedAndAdult, err := spec.AllOf("VerifiedAndAdult", isVerified, isAdult)
+	if err != nil {
+		t.Fatal(err)
+	}
+	financiallyQualified, err := spec.AnyOf("FinanciallyQualified", hasFunds, verifiedAndAdult)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// passes because hasFunds passes
 	result := financiallyQualified.Evaluate(testCtx{Balance: 200})
@@ -241,8 +285,14 @@ func TestNested_AnyOfWithAllOf(t *testing.T) {
 }
 
 func TestNested_Expression(t *testing.T) {
-	inner := spec.AllOf("Inner", isAdult, hasFunds)
-	outer := spec.AnyOf("Outer", isVerified, inner)
+	inner, err := spec.AllOf("Inner", isAdult, hasFunds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outer, err := spec.AnyOf("Outer", isVerified, inner)
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := "(IsVerified OR (IsAdult AND HasFunds))"
 	if outer.Expression() != want {
 		t.Errorf("Expression() = %q, want %q", outer.Expression(), want)

--- a/pkg/spec/composite_test.go
+++ b/pkg/spec/composite_test.go
@@ -10,10 +10,13 @@ import (
 
 func TestAnyOf_PassesWhenFirstSpecPasses(t *testing.T) {
 	s, err := spec.AnyOf("combo", isAdult, hasFunds)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	result := s.Evaluate(testCtx{Age: 20, Balance: 0})
+
 	if !result.Passed() {
 		t.Error("expected pass when first spec passes")
 	}
@@ -21,10 +24,13 @@ func TestAnyOf_PassesWhenFirstSpecPasses(t *testing.T) {
 
 func TestAnyOf_PassesWhenSecondSpecPasses(t *testing.T) {
 	s, err := spec.AnyOf("combo", isAdult, hasFunds)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	result := s.Evaluate(testCtx{Age: 16, Balance: 200})
+
 	if !result.Passed() {
 		t.Error("expected pass when second spec passes")
 	}
@@ -32,10 +38,13 @@ func TestAnyOf_PassesWhenSecondSpecPasses(t *testing.T) {
 
 func TestAnyOf_FailsWhenAllSpecsFail(t *testing.T) {
 	s, err := spec.AnyOf("combo", isAdult, hasFunds)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	result := s.Evaluate(testCtx{Age: 16, Balance: 50})
+
 	if result.Passed() {
 		t.Error("expected fail when all specs fail")
 	}
@@ -43,10 +52,13 @@ func TestAnyOf_FailsWhenAllSpecsFail(t *testing.T) {
 
 func TestAnyOf_CollectsAllReasonsOnFailure(t *testing.T) {
 	s, err := spec.AnyOf("combo", isAdult, hasFunds)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	result := s.Evaluate(testCtx{Age: 16, Balance: 50})
+
 	if len(result.FailureReasons()) != 2 {
 		t.Errorf("FailureReasons() len = %d, want 2", len(result.FailureReasons()))
 	}
@@ -64,9 +76,11 @@ func TestAnyOf_ShortCircuitsOnFirstPass(t *testing.T) {
 	}, blocked)
 
 	s, err := spec.AnyOf("combo", counter, never)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	s.Evaluate(testCtx{})
 
 	if evalCount != 1 {
@@ -76,10 +90,13 @@ func TestAnyOf_ShortCircuitsOnFirstPass(t *testing.T) {
 
 func TestAnyOf_Expression(t *testing.T) {
 	s, err := spec.AnyOf("combo", isAdult, hasFunds)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	want := "(IsAdult OR HasFunds)"
+
 	if s.Expression() != want {
 		t.Errorf("Expression() = %q, want %q", s.Expression(), want)
 	}
@@ -87,9 +104,11 @@ func TestAnyOf_Expression(t *testing.T) {
 
 func TestAnyOf_SingleSpec(t *testing.T) {
 	s, err := spec.AnyOf("single", isAdult)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if s.Expression() != "IsAdult" {
 		t.Errorf("Expression() = %q, want %q", s.Expression(), "IsAdult")
 	}
@@ -97,6 +116,7 @@ func TestAnyOf_SingleSpec(t *testing.T) {
 
 func TestAnyOf_ErrorOnEmpty(t *testing.T) {
 	_, err := spec.AnyOf[testCtx, testReason]("empty")
+
 	if err == nil {
 		t.Error("expected error for empty specs")
 	}
@@ -108,16 +128,18 @@ func TestAnyOfAll_EvaluatesAllSpecs(t *testing.T) {
 	evalCount := 0
 	s1 := spec.New("S1", func(c testCtx) bool { evalCount++; return true }, blocked)
 	s2 := spec.New("S2", func(c testCtx) bool { evalCount++; return false }, blocked)
-
 	s, err := spec.AnyOfAll("combo", s1, s2)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	result := s.Evaluate(testCtx{})
 
 	if evalCount != 2 {
 		t.Errorf("evalCount = %d, want 2 (no short-circuit)", evalCount)
 	}
+
 	if !result.Passed() {
 		t.Error("expected pass because s1 passed")
 	}
@@ -125,9 +147,11 @@ func TestAnyOfAll_EvaluatesAllSpecs(t *testing.T) {
 
 func TestAnyOfAll_FailsWhenAllFail(t *testing.T) {
 	s, err := spec.AnyOfAll("combo", alwaysFail, alwaysFail)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if s.Evaluate(testCtx{}).Passed() {
 		t.Error("expected fail when all specs fail")
 	}
@@ -135,6 +159,7 @@ func TestAnyOfAll_FailsWhenAllFail(t *testing.T) {
 
 func TestAnyOfAll_ErrorOnEmpty(t *testing.T) {
 	_, err := spec.AnyOfAll[testCtx, testReason]("empty")
+
 	if err == nil {
 		t.Error("expected error for empty specs")
 	}
@@ -142,13 +167,17 @@ func TestAnyOfAll_ErrorOnEmpty(t *testing.T) {
 
 func TestAnyOfAll_CollectsAllReasonsOnFailure(t *testing.T) {
 	s, err := spec.AnyOfAll("combo", isAdult, hasFunds)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	result := s.Evaluate(testCtx{Age: 16, Balance: 50})
+
 	if result.Passed() {
 		t.Error("expected fail")
 	}
+
 	if len(result.FailureReasons()) != 2 {
 		t.Errorf("FailureReasons() len = %d, want 2", len(result.FailureReasons()))
 	}
@@ -158,10 +187,13 @@ func TestAnyOfAll_CollectsAllReasonsOnFailure(t *testing.T) {
 
 func TestAllOf_PassesWhenAllSpecsPass(t *testing.T) {
 	s, err := spec.AllOf("combo", isAdult, hasFunds)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	result := s.Evaluate(testCtx{Age: 20, Balance: 200})
+
 	if !result.Passed() {
 		t.Error("expected pass when all specs pass")
 	}
@@ -169,10 +201,13 @@ func TestAllOf_PassesWhenAllSpecsPass(t *testing.T) {
 
 func TestAllOf_FailsWhenFirstFails(t *testing.T) {
 	s, err := spec.AllOf("combo", isAdult, hasFunds)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	result := s.Evaluate(testCtx{Age: 16, Balance: 200})
+
 	if result.Passed() {
 		t.Error("expected fail when first spec fails")
 	}
@@ -180,10 +215,13 @@ func TestAllOf_FailsWhenFirstFails(t *testing.T) {
 
 func TestAllOf_CollectsAllFailureReasons(t *testing.T) {
 	s, err := spec.AllOf("combo", isAdult, hasFunds)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	result := s.Evaluate(testCtx{Age: 16, Balance: 50})
+
 	if len(result.FailureReasons()) != 2 {
 		t.Errorf("FailureReasons() len = %d, want 2", len(result.FailureReasons()))
 	}
@@ -193,11 +231,12 @@ func TestAllOf_EvaluatesAllSpecsEvenOnFailure(t *testing.T) {
 	evalCount := 0
 	s1 := spec.New("S1", func(c testCtx) bool { evalCount++; return false }, tooYoung)
 	s2 := spec.New("S2", func(c testCtx) bool { evalCount++; return false }, insufficientFunds)
-
 	s, err := spec.AllOf("combo", s1, s2)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	s.Evaluate(testCtx{})
 
 	if evalCount != 2 {
@@ -207,10 +246,13 @@ func TestAllOf_EvaluatesAllSpecsEvenOnFailure(t *testing.T) {
 
 func TestAllOf_Expression(t *testing.T) {
 	s, err := spec.AllOf("combo", isAdult, hasFunds)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	want := "(IsAdult AND HasFunds)"
+
 	if s.Expression() != want {
 		t.Errorf("Expression() = %q, want %q", s.Expression(), want)
 	}
@@ -218,6 +260,7 @@ func TestAllOf_Expression(t *testing.T) {
 
 func TestAllOf_ErrorOnEmpty(t *testing.T) {
 	_, err := spec.AllOf[testCtx, testReason]("empty")
+
 	if err == nil {
 		t.Error("expected error for empty specs")
 	}
@@ -228,6 +271,7 @@ func TestAllOf_ErrorOnEmpty(t *testing.T) {
 func TestNot_PassesWhenInnerFails(t *testing.T) {
 	s := spec.Not("IsMinor", tooOld, isAdult)
 	result := s.Evaluate(testCtx{Age: 16}) // isAdult fails → Not passes
+
 	if !result.Passed() {
 		t.Error("expected pass when inner spec fails")
 	}
@@ -236,10 +280,13 @@ func TestNot_PassesWhenInnerFails(t *testing.T) {
 func TestNot_FailsWhenInnerPasses(t *testing.T) {
 	s := spec.Not("IsMinor", tooOld, isAdult)
 	result := s.Evaluate(testCtx{Age: 20}) // isAdult passes → Not fails
+
 	if result.Passed() {
 		t.Error("expected fail when inner spec passes")
 	}
+
 	reasons := result.FailureReasons()
+
 	if len(reasons) != 1 || reasons[0] != tooOld {
 		t.Errorf("FailureReasons() = %v, want [%v]", reasons, tooOld)
 	}
@@ -248,6 +295,7 @@ func TestNot_FailsWhenInnerPasses(t *testing.T) {
 func TestNot_Expression(t *testing.T) {
 	s := spec.Not("IsMinor", tooOld, isAdult)
 	want := "NOT IsAdult"
+
 	if s.Expression() != want {
 		t.Errorf("Expression() = %q, want %q", s.Expression(), want)
 	}
@@ -257,28 +305,34 @@ func TestNot_Expression(t *testing.T) {
 
 func TestNested_AnyOfWithAllOf(t *testing.T) {
 	verifiedAndAdult, err := spec.AllOf("VerifiedAndAdult", isVerified, isAdult)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	financiallyQualified, err := spec.AnyOf("FinanciallyQualified", hasFunds, verifiedAndAdult)
+
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// passes because hasFunds passes
 	result := financiallyQualified.Evaluate(testCtx{Balance: 200})
+
 	if !result.Passed() {
 		t.Error("expected pass via hasFunds")
 	}
 
 	// passes because isVerified AND isAdult pass
 	result = financiallyQualified.Evaluate(testCtx{Age: 20, Verified: true})
+
 	if !result.Passed() {
 		t.Error("expected pass via VerifiedAndAdult")
 	}
 
 	// fails because neither branch passes
 	result = financiallyQualified.Evaluate(testCtx{Age: 16, Balance: 50})
+
 	if result.Passed() {
 		t.Error("expected fail when neither branch passes")
 	}
@@ -286,14 +340,19 @@ func TestNested_AnyOfWithAllOf(t *testing.T) {
 
 func TestNested_Expression(t *testing.T) {
 	inner, err := spec.AllOf("Inner", isAdult, hasFunds)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	outer, err := spec.AnyOf("Outer", isVerified, inner)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	want := "(IsVerified OR (IsAdult AND HasFunds))"
+
 	if outer.Expression() != want {
 		t.Errorf("Expression() = %q, want %q", outer.Expression(), want)
 	}

--- a/pkg/spec/policy.go
+++ b/pkg/spec/policy.go
@@ -26,13 +26,16 @@ func (p *Policy[T, R]) With(s Specification[T, R]) *Policy[T, R] {
 // Use this when you only need to know whether a policy passes and want minimal evaluation.
 func (p *Policy[T, R]) EvaluateFailFast(ctx T) PolicyResult[R] {
 	var results []SpecificationResult[R]
+
 	for _, s := range p.specs {
 		res := s.Evaluate(ctx)
 		results = append(results, res)
+
 		if !res.Passed() {
 			return newPolicyResult(false, results)
 		}
 	}
+
 	return newPolicyResult(true, results)
 }
 
@@ -41,13 +44,16 @@ func (p *Policy[T, R]) EvaluateFailFast(ctx T) PolicyResult[R] {
 func (p *Policy[T, R]) EvaluateAll(ctx T) PolicyResult[R] {
 	allPassed := true
 	results := make([]SpecificationResult[R], 0, len(p.specs))
+
 	for _, s := range p.specs {
 		res := s.Evaluate(ctx)
 		results = append(results, res)
+
 		if !res.Passed() {
 			allPassed = false
 		}
 	}
+
 	return newPolicyResult(allPassed, results)
 }
 
@@ -57,9 +63,12 @@ func (p *Policy[T, R]) String() string {
 	if len(p.specs) == 0 {
 		return "()"
 	}
+
 	parts := make([]string, len(p.specs))
+
 	for i, s := range p.specs {
 		parts[i] = s.Expression()
 	}
+
 	return fmt.Sprintf("(%s)", strings.Join(parts, " AND "))
 }

--- a/pkg/spec/policy_result.go
+++ b/pkg/spec/policy_result.go
@@ -10,33 +10,42 @@ type PolicyResult[R comparable] struct {
 func newPolicyResult[R comparable](allPassed bool, results []SpecificationResult[R]) PolicyResult[R] {
 	r := make([]SpecificationResult[R], len(results))
 	copy(r, results)
+
 	return PolicyResult[R]{allPassed: allPassed, results: r}
 }
 
 // AllPassed reports whether every specification in the policy passed.
-func (pr PolicyResult[R]) AllPassed() bool { return pr.allPassed }
+func (pr PolicyResult[R]) AllPassed() bool {
+	return pr.allPassed
+}
 
 // Results returns all specification results (both passed and failed).
-func (pr PolicyResult[R]) Results() []SpecificationResult[R] { return pr.results }
+func (pr PolicyResult[R]) Results() []SpecificationResult[R] {
+	return pr.results
+}
 
 // FailedResults returns only the results where the specification failed.
 func (pr PolicyResult[R]) FailedResults() []SpecificationResult[R] {
 	var failed []SpecificationResult[R]
+
 	for _, r := range pr.results {
 		if !r.Passed() {
 			failed = append(failed, r)
 		}
 	}
+
 	return failed
 }
 
 // FailureReasons returns a flattened list of all failure reasons across all failed specifications.
 func (pr PolicyResult[R]) FailureReasons() []R {
 	var reasons []R
+
 	for _, r := range pr.results {
 		if !r.Passed() {
 			reasons = append(reasons, r.FailureReasons()...)
 		}
 	}
+
 	return reasons
 }

--- a/pkg/spec/policy_result_test.go
+++ b/pkg/spec/policy_result_test.go
@@ -9,6 +9,7 @@ import (
 func TestPolicyResult_AllPassedTrue(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]().With(alwaysPass).With(isAdult)
 	result := p.EvaluateAll(testCtx{Age: 20})
+
 	if !result.AllPassed() {
 		t.Error("AllPassed() = false, want true")
 	}
@@ -17,6 +18,7 @@ func TestPolicyResult_AllPassedTrue(t *testing.T) {
 func TestPolicyResult_AllPassedFalse(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]().With(alwaysPass).With(alwaysFail)
 	result := p.EvaluateAll(testCtx{})
+
 	if result.AllPassed() {
 		t.Error("AllPassed() = true, want false")
 	}
@@ -25,8 +27,8 @@ func TestPolicyResult_AllPassedFalse(t *testing.T) {
 func TestPolicyResult_FailedResults(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]().With(isAdult).With(hasFunds).With(isVerified)
 	result := p.EvaluateAll(testCtx{Age: 16, Balance: 50, Verified: false})
-
 	failed := result.FailedResults()
+
 	if len(failed) != 3 {
 		t.Errorf("len(FailedResults()) = %d, want 3", len(failed))
 	}
@@ -44,8 +46,8 @@ func TestPolicyResult_FailedResults_EmptyWhenAllPass(t *testing.T) {
 func TestPolicyResult_FailureReasons(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]().With(isAdult).With(hasFunds)
 	result := p.EvaluateAll(testCtx{Age: 16, Balance: 50})
-
 	reasons := result.FailureReasons()
+
 	if len(reasons) != 2 {
 		t.Errorf("len(FailureReasons()) = %d, want 2", len(reasons))
 	}

--- a/pkg/spec/policy_test.go
+++ b/pkg/spec/policy_test.go
@@ -11,6 +11,7 @@ import (
 func TestNewPolicy_StartsEmpty(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]()
 	result := p.EvaluateAll(testCtx{})
+
 	if !result.AllPassed() {
 		t.Error("empty policy should pass")
 	}
@@ -19,6 +20,7 @@ func TestNewPolicy_StartsEmpty(t *testing.T) {
 func TestPolicy_WithReturnsSamePolicy(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]()
 	returned := p.With(alwaysPass)
+
 	if p != returned {
 		t.Error("With() should return the same policy pointer")
 	}
@@ -31,6 +33,7 @@ func TestPolicy_FluentChain(t *testing.T) {
 		With(isVerified)
 
 	result := p.EvaluateAll(testCtx{Age: 20, Balance: 200, Verified: true})
+
 	if !result.AllPassed() {
 		t.Error("expected all to pass")
 	}
@@ -41,6 +44,7 @@ func TestPolicy_FluentChain(t *testing.T) {
 func TestEvaluateFailFast_PassesWhenAllSpecsPass(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]().With(isAdult).With(hasFunds)
 	result := p.EvaluateFailFast(testCtx{Age: 20, Balance: 200})
+
 	if !result.AllPassed() {
 		t.Error("expected pass")
 	}
@@ -74,8 +78,8 @@ func TestEvaluateFailFast_ResultsContainOnlyEvaluated(t *testing.T) {
 func TestEvaluateFailFast_ReturnsFailureReasonOfFirstFailedSpec(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]().With(isAdult).With(hasFunds)
 	result := p.EvaluateFailFast(testCtx{Age: 16, Balance: 50})
-
 	reasons := result.FailureReasons()
+
 	if len(reasons) != 1 || reasons[0] != tooYoung {
 		t.Errorf("FailureReasons() = %v, want [%v]", reasons, tooYoung)
 	}
@@ -86,6 +90,7 @@ func TestEvaluateFailFast_ReturnsFailureReasonOfFirstFailedSpec(t *testing.T) {
 func TestEvaluateAll_PassesWhenAllSpecsPass(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]().With(isAdult).With(hasFunds)
 	result := p.EvaluateAll(testCtx{Age: 20, Balance: 200})
+
 	if !result.AllPassed() {
 		t.Error("expected pass")
 	}
@@ -95,7 +100,6 @@ func TestEvaluateAll_EvaluatesAllSpecs(t *testing.T) {
 	evalCount := 0
 	s1 := spec.New("S1", func(c testCtx) bool { evalCount++; return false }, tooYoung)
 	s2 := spec.New("S2", func(c testCtx) bool { evalCount++; return false }, insufficientFunds)
-
 	p := spec.NewPolicy[testCtx, testReason]().With(s1).With(s2)
 	p.EvaluateAll(testCtx{})
 
@@ -111,6 +115,7 @@ func TestEvaluateAll_CollectsAllFailureReasons(t *testing.T) {
 	if result.AllPassed() {
 		t.Error("expected fail")
 	}
+
 	if len(result.FailureReasons()) != 3 {
 		t.Errorf("len(FailureReasons()) = %d, want 3", len(result.FailureReasons()))
 	}
@@ -129,6 +134,7 @@ func TestEvaluateAll_ResultsContainAll(t *testing.T) {
 
 func TestPolicy_StringEmpty(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]()
+
 	if p.String() != "()" {
 		t.Errorf("String() = %q, want %q", p.String(), "()")
 	}
@@ -136,6 +142,7 @@ func TestPolicy_StringEmpty(t *testing.T) {
 
 func TestPolicy_StringSingleSpec(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]().With(isAdult)
+
 	if p.String() != "(IsAdult)" {
 		t.Errorf("String() = %q, want %q", p.String(), "(IsAdult)")
 	}
@@ -143,6 +150,7 @@ func TestPolicy_StringSingleSpec(t *testing.T) {
 
 func TestPolicy_StringMultipleSpecs(t *testing.T) {
 	p := spec.NewPolicy[testCtx, testReason]().With(isAdult).With(hasFunds)
+
 	if p.String() != "(IsAdult AND HasFunds)" {
 		t.Errorf("String() = %q, want %q", p.String(), "(IsAdult AND HasFunds)")
 	}
@@ -150,11 +158,14 @@ func TestPolicy_StringMultipleSpecs(t *testing.T) {
 
 func TestPolicy_StringWithComposite(t *testing.T) {
 	financiallyQualified, err := spec.AnyOf("FinanciallyQualified", hasFunds, isVerified)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	p := spec.NewPolicy[testCtx, testReason]().With(isAdult).With(financiallyQualified)
 	want := "(IsAdult AND (HasFunds OR IsVerified))"
+
 	if p.String() != want {
 		t.Errorf("String() = %q, want %q", p.String(), want)
 	}

--- a/pkg/spec/policy_test.go
+++ b/pkg/spec/policy_test.go
@@ -149,7 +149,10 @@ func TestPolicy_StringMultipleSpecs(t *testing.T) {
 }
 
 func TestPolicy_StringWithComposite(t *testing.T) {
-	financiallyQualified := spec.AnyOf("FinanciallyQualified", hasFunds, isVerified)
+	financiallyQualified, err := spec.AnyOf("FinanciallyQualified", hasFunds, isVerified)
+	if err != nil {
+		t.Fatal(err)
+	}
 	p := spec.NewPolicy[testCtx, testReason]().With(isAdult).With(financiallyQualified)
 	want := "(IsAdult AND (HasFunds OR IsVerified))"
 	if p.String() != want {

--- a/pkg/spec/result.go
+++ b/pkg/spec/result.go
@@ -8,18 +8,24 @@ type SpecificationResult[R comparable] struct {
 }
 
 // Name returns the name of the specification that produced this result.
-func (r SpecificationResult[R]) Name() string { return r.name }
+func (r SpecificationResult[R]) Name() string {
+	return r.name
+}
 
 // Passed reports whether the specification passed (no failure reasons).
-func (r SpecificationResult[R]) Passed() bool { return r.failureReasons == nil }
+func (r SpecificationResult[R]) Passed() bool {
+	return r.failureReasons == nil
+}
 
 // FailureReasons returns a copy of the failure reasons, or nil if the specification passed.
 func (r SpecificationResult[R]) FailureReasons() []R {
 	if r.failureReasons == nil {
 		return nil
 	}
+
 	out := make([]R, len(r.failureReasons))
 	copy(out, r.failureReasons)
+
 	return out
 }
 
@@ -32,5 +38,6 @@ func Pass[R comparable](name string) SpecificationResult[R] {
 func Fail[R comparable](name string, reasons ...R) SpecificationResult[R] {
 	r := make([]R, len(reasons))
 	copy(r, reasons)
+
 	return SpecificationResult[R]{name: name, failureReasons: r}
 }

--- a/pkg/spec/result_test.go
+++ b/pkg/spec/result_test.go
@@ -12,9 +12,11 @@ func TestPass(t *testing.T) {
 	if r.Name() != "MySpec" {
 		t.Errorf("Name() = %q, want %q", r.Name(), "MySpec")
 	}
+
 	if !r.Passed() {
 		t.Error("Passed() = false, want true")
 	}
+
 	if r.FailureReasons() != nil {
 		t.Errorf("FailureReasons() = %v, want nil", r.FailureReasons())
 	}
@@ -26,16 +28,21 @@ func TestFail(t *testing.T) {
 	if r.Name() != "MySpec" {
 		t.Errorf("Name() = %q, want %q", r.Name(), "MySpec")
 	}
+
 	if r.Passed() {
 		t.Error("Passed() = true, want false")
 	}
+
 	reasons := r.FailureReasons()
+
 	if len(reasons) != 2 {
 		t.Fatalf("len(FailureReasons()) = %d, want 2", len(reasons))
 	}
+
 	if reasons[0] != tooYoung {
 		t.Errorf("FailureReasons()[0] = %v, want %v", reasons[0], tooYoung)
 	}
+
 	if reasons[1] != insufficientFunds {
 		t.Errorf("FailureReasons()[1] = %v, want %v", reasons[1], insufficientFunds)
 	}
@@ -47,6 +54,7 @@ func TestFailSingleReason(t *testing.T) {
 	if r.Passed() {
 		t.Error("Passed() = true, want false")
 	}
+
 	if len(r.FailureReasons()) != 1 {
 		t.Errorf("len(FailureReasons()) = %d, want 1", len(r.FailureReasons()))
 	}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -22,16 +22,21 @@ type Func[T any, R comparable] struct {
 }
 
 // Evaluate implements [Specification].
-func (f Func[T, R]) Evaluate(ctx T) SpecificationResult[R] { return f.fn(ctx) }
+func (f Func[T, R]) Evaluate(ctx T) SpecificationResult[R] {
+	return f.fn(ctx)
+}
 
 // Name implements [Specification].
-func (f Func[T, R]) Name() string { return f.name }
+func (f Func[T, R]) Name() string {
+	return f.name
+}
 
 // Expression implements [Specification]. Falls back to Name if no expression was set.
 func (f Func[T, R]) Expression() string {
 	if f.expression != "" {
 		return f.expression
 	}
+
 	return f.name
 }
 
@@ -44,6 +49,7 @@ func New[T any, R comparable](name string, predicate func(T) bool, reason R) Spe
 			if predicate(ctx) {
 				return Pass[R](name)
 			}
+
 			return Fail(name, reason)
 		},
 	}
@@ -66,7 +72,11 @@ type NamedSpec[T any, R comparable] struct {
 }
 
 // Name implements [Specification].
-func (n NamedSpec[T, R]) Name() string { return n.N }
+func (n NamedSpec[T, R]) Name() string {
+	return n.N
+}
 
 // Expression implements [Specification].
-func (n NamedSpec[T, R]) Expression() string { return n.N }
+func (n NamedSpec[T, R]) Expression() string {
+	return n.N
+}

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -91,7 +91,7 @@ func TestNew_BoundaryAge(t *testing.T) {
 
 	for _, tc := range cases {
 		result := isAdult.Evaluate(testCtx{Age: tc.age})
-		
+
 		if result.Passed() != tc.passes {
 			t.Errorf("age %d: Passed() = %v, want %v", tc.age, result.Passed(), tc.passes)
 		}

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -22,7 +22,9 @@ func TestNew_FailsWhenPredicateFalse(t *testing.T) {
 	if result.Passed() {
 		t.Errorf("expected fail for age %d", ctx.Age)
 	}
+
 	reasons := result.FailureReasons()
+
 	if len(reasons) != 1 || reasons[0] != tooYoung {
 		t.Errorf("FailureReasons() = %v, want [%v]", reasons, tooYoung)
 	}
@@ -30,6 +32,7 @@ func TestNew_FailsWhenPredicateFalse(t *testing.T) {
 
 func TestNew_ResultName(t *testing.T) {
 	result := isAdult.Evaluate(testCtx{Age: 20})
+
 	if result.Name() != "IsAdult" {
 		t.Errorf("result.Name() = %q, want %q", result.Name(), "IsAdult")
 	}
@@ -53,6 +56,7 @@ func TestFunc_CustomExpression(t *testing.T) {
 
 	// Func with explicit expression
 	s2 := spec.New("AgeCheck", func(c testCtx) bool { return c.Age >= 18 }, tooYoung)
+
 	if s2.Expression() != "AgeCheck" {
 		t.Errorf("Expression() = %q, want %q", s2.Expression(), "AgeCheck")
 	}
@@ -62,11 +66,14 @@ func TestNamedSpec_ImplementsSpecification(t *testing.T) {
 	type mySpec struct {
 		spec.NamedSpec[testCtx, testReason]
 	}
+
 	// NamedSpec must satisfy Name() and Expression() so a custom struct only needs Evaluate.
 	n := spec.NamedSpec[testCtx, testReason]{N: "CustomSpec"}
+
 	if n.Name() != "CustomSpec" {
 		t.Errorf("Name() = %q, want %q", n.Name(), "CustomSpec")
 	}
+
 	if n.Expression() != "CustomSpec" {
 		t.Errorf("Expression() = %q, want %q", n.Expression(), "CustomSpec")
 	}
@@ -81,8 +88,10 @@ func TestNew_BoundaryAge(t *testing.T) {
 		{18, true},
 		{19, true},
 	}
+
 	for _, tc := range cases {
 		result := isAdult.Evaluate(testCtx{Age: tc.age})
+		
 		if result.Passed() != tc.passes {
 			t.Errorf("age %d: Passed() = %v, want %v", tc.age, result.Passed(), tc.passes)
 		}


### PR DESCRIPTION
## 📝 Description

`AnyOf`, `AnyOfAll`, and `AllOf` previously panicked when called with zero specifications. As a library, panicking is inappropriate — it crashes the calling application with no way to recover gracefully. These functions now return `(Specification[T, R], error)` so callers can handle the invalid input explicitly.

## 🎯 Related Issue

Closes #8

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation (changes to documentation only)
- [ ] 🧹 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Tests (adding or updating tests)

## ✅ Checklist

- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`go test ./... -race`)
- [ ] I have updated documentation if needed

## 📎 Additional Notes

`Panics on empty` tests have been replaced with `Error on empty` tests. All call sites in `examples/loan/main.go`, `composite_test.go`, `policy_test.go`, and the nested composition tests have been updated to handle the new signatures.
