### PR TITLE
fix: use GH_PAT for tag push so release-publish workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
 
       - name: Determine version bump
         id: bump


### PR DESCRIPTION
## Problem

When the `tag` job in `release.yml` pushes a new tag using the default `GITHUB_TOKEN`, GitHub intentionally does not trigger other workflows from that push (to prevent infinite loops). This caused `release-publish.yml` to never fire after a new tag was created.

## Fix

Add `token: ${{ secrets.GH_PAT }}` to the checkout step in the `tag` job. When the tag is pushed using a PAT, GitHub allows it to trigger downstream workflows — including `release-publish.yml`.

## Prerequisites

`GH_PAT` must be set as a repository secret with `Contents: write` permission.
